### PR TITLE
Add dynamic elements from namespaces to publish.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This plugin supports publishing metrics to Elasticsearch endpoint
 
-It is used in the [snap framework] (http://github.com/intelsdi-x/snap).
+It is used in the [Snap framework] (http://github.com/intelsdi-x/snap).
 
 
 1. [Getting Started](#getting-started)
@@ -58,10 +58,11 @@ You can also set following options if needed:
  - `index_timestamp` default is set to `true` (boolean). Set to false if not want to extend index prefix with timestamp
  - `publish_fields` default is set to `Namespace|Config|Data|Description|Timestamp|Unit|Version` (string). Remove field from metric structure which shouldn't be published.
 
+Plugin publishes dynamic elements from metric namespace.
 
 ### Examples
 
-Not yet provided!
+You can find example task manifest for using this plugin in folder [examples](https://github.com/intelsdi-x/snap-plugin-publisher-elasticsearch/examples)
 
 ### Roadmap
 
@@ -69,7 +70,7 @@ If you have a feature request, please add it as an [issue](https://github.com/in
 and/or submit a [pull request](https://github.com/intelsdi-x/snap-plugin-publisher-elasticsearch/pulls).
 
 ## Community Support
-This repository is one of **many** plugins in the **snap**, a powerful telemetry agent framework. See the full project at 
+This repository is one of **many** plugins in the **Snap**, a powerful telemetry agent framework. See the full project at 
 http://github.com/intelsdi-x/snap. To reach out to other users, head to the [main framework](https://github.com/intelsdi-x/snap#community-support).
 
 
@@ -80,7 +81,7 @@ There is more than one way to give back, from examples to blogs to code updates.
 
 ## License
 
-[snap](http://github.com/intelsdi-x/snap), along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
+[Snap](http://github.com/intelsdi-x/snap), along with this plugin, is an Open Source software released under the Apache 2.0 [License](LICENSE).
 
 
 ## Acknowledgements

--- a/elasticsearch/elasticsearch.go
+++ b/elasticsearch/elasticsearch.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -97,6 +97,11 @@ func sendRequest(metric plugin.Metric, url string, fieldsToPublish []string) err
 
 	for k, v := range metric.Tags {
 		metricToPublish[k] = v
+	}
+	for _, element := range metric.Namespace {
+		if element.IsDynamic() {
+			metricToPublish[element.Name] = element.Value
+		}
 	}
 	data, err := json.Marshal(metricToPublish)
 	if err != nil {

--- a/elasticsearch/elasticsearch_small_test.go
+++ b/elasticsearch/elasticsearch_small_test.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/examples/task_manifest.json
+++ b/examples/task_manifest.json
@@ -1,0 +1,29 @@
+{
+  "version": 1,
+  "schedule": {
+    "type": "simple",
+    "interval": "5s"
+  },
+  "workflow": {
+    "collect": {
+      "metrics": {
+        "/intel/foo/bar/": {}
+      },
+      "config": {
+      },
+      "publish": [
+        {
+          "plugin_name": "elasticsearch",
+          "config": {
+            "protocol": "http",
+            "address": "172.0.0.1",
+            "port": 9200,
+            "index": "bar",
+            "type": "message",
+            "publish_fields": "Namespace|Data|Timestamp"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	pluginName = "elasticsearch"
+	pluginName    = "elasticsearch"
 	pluginVersion = 1
 )
 

--- a/main_small_test.go
+++ b/main_small_test.go
@@ -2,7 +2,7 @@
 http://www.apache.org/licenses/LICENSE-2.0.txt
 
 
-Copyright 2015 Intel Corporation
+Copyright 2016 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes #3

Summary of changes:
- Fix for #3
- Add example task manifest

How to verify it:
- Dynamic elements of namespace published to elasticsearch

Testing done:
- Medium/Small

